### PR TITLE
Bug Fix: The APIList Discovery Client cannot retrieve updates.

### DIFF
--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -52,7 +52,7 @@ func GetResponseType(typeURL string) types.ResponseType {
 		return types.API
 	case resource.SubscriptionListType:
 		return types.SubscriptionList
-	case resource.ApiListType:
+	case resource.APIListType:
 		return types.ApiList
 	case resource.ApplicationListType:
 		return types.ApplicationList

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -21,7 +21,7 @@ const (
 	APIType                       = apiTypePrefix + "wso2.discovery.api.Api"
 	SubscriptionListType          = apiTypePrefix + "wso2.discovery.subscription.SubscriptionList"
 	ApplicationListType           = apiTypePrefix + "wso2.discovery.subscription.ApplicationList"
-	ApiListType                   = apiTypePrefix + "wso2.discovery.subscription.ApiList"
+	APIListType                   = apiTypePrefix + "wso2.discovery.subscription.APIList"
 	ApplicationPolicyListType     = apiTypePrefix + "wso2.discovery.subscription.ApplicationPolicyList"
 	SubscriptionPolicyListType    = apiTypePrefix + "wso2.discovery.subscription.SubscriptionPolicyList"
 	ApplicationKeyMappingListType = apiTypePrefix + "wso2.discovery.subscription.ApplicationKeyMappingList"

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -339,7 +339,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "apiList watch failed")
 			}
-			nonce, err := send(resp, resource.ApiListType)
+			nonce, err := send(resp, resource.APIListType)
 			if err != nil {
 				return err
 			}
@@ -497,7 +497,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 					}
 					values.subscriptionList, values.subscriptionListCancel = s.cache.CreateWatch(req)
 				}
-			case req.TypeUrl == resource.ApiListType:
+			case req.TypeUrl == resource.APIListType:
 				if values.apiListNonce == "" || values.apiListNonce == nonce {
 					if values.apiListCancel != nil {
 						values.apiListCancel()

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -195,7 +195,7 @@ func (s *server) StreamSubscriptions(stream subscriptionservice.SubscriptionDisc
 }
 
 func (s *server) StreamApiList(stream subscriptionservice.ApiListDiscoveryService_StreamApiListServer) error {
-	return s.StreamHandler(stream, resource.ApiListType)
+	return s.StreamHandler(stream, resource.APIListType)
 }
 
 func (s *server) StreamApplications(stream subscriptionservice.ApplicationDiscoveryService_StreamApplicationsServer) error {


### PR DESCRIPTION
$subject and this results in creating a large number of discovery requests repeatedly.